### PR TITLE
Add inversible undos

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ further.
 
 The editor is very much a work in progress and currently is not even close to being
 functional. The roadmap is as follows:
-- [ ] Create the editor's buffer
+- [X] Create the editor's buffer
   - [X] Implement a piece table
-  - [ ] Allow for undos that properly restore the state of the piece table
+  - [X] Allow for undos and redos that properly restore the state of the piece table
   - [ ] Record timestamps for every edit to allow for exploring the file over
     time
 - [ ] Set up the rudiments of the editor itself. Should have no knowledge of rendering, just

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ functional. The roadmap is as follows:
   - [X] Implement a piece table
   - [ ] Allow for undos that properly restore the state of the piece table
   - [ ] Record timestamps for every edit to allow for exploring the file over
-    time in the future
+    time
 - [ ] Set up the rudiments of the editor itself. Should have no knowledge of rendering, just
       implements functionality over buffers.
 - [ ] Include Lua for editor extensibility.

--- a/src/byt/io/file/mod.rs
+++ b/src/byt/io/file/mod.rs
@@ -85,6 +85,22 @@ struct Action {
     merge_up   : bool,
 }
 
+impl fmt::Display for Action {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "op={:?} {}+{} down={} up={}\n",
+               self.op,
+               self.offset,
+               self.length,
+               self.merge_down,
+               self.merge_up);
+        write!(f, "action pieces\n");
+        for piece in &self.pieces {
+            write!(f, "{}\n", piece);
+        }
+        write!(f, "end of action pieces\n")
+    }
+}
+
 /// Implements logical operations on a file that are not written
 /// until asked to.
 pub struct PieceFile {
@@ -107,6 +123,21 @@ pub struct PieceFile {
     piece_table : Vec<Piece>,
     /// The seekable file reader.
     reader : Option<BufReader<File>>,
+}
+
+impl fmt::Display for PieceFile {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "PieceFile\n");
+        write!(f, "history_offset={}\n", self.history_offset);
+        write!(f, "length={}\n", self.length);
+        write!(f, "offset={}\n", self.offset);
+        write!(f, "path={}\n", self.path);
+        write!(f, "piece_table len({})\n", self.piece_table.len());
+        for piece in &self.piece_table {
+            write!(f, "{}\n", piece);
+        }
+        write!(f, "end piece table")
+    }
 }
 
 impl PieceFile {
@@ -146,7 +177,7 @@ impl PieceFile {
             action.pieces.push(Piece {
                 file           : piece.file,
                 file_offset    : piece.file_offset + lower_size,
-                length         : delete_size,
+                length         : length,
                 logical_offset : start_offset,
             });
 
@@ -159,7 +190,7 @@ impl PieceFile {
             if upper_size > 0 {
                 self.piece_table.insert(start_index, Piece {
                     file           : piece.file,
-                    file_offset    : piece.file_offset + lower_size + delete_size,
+                    file_offset    : piece.file_offset + lower_size + length,
                     length         : upper_size,
                     logical_offset : start_offset,
                 });

--- a/src/byt/io/file/mod.rs
+++ b/src/byt/io/file/mod.rs
@@ -136,7 +136,12 @@ impl fmt::Display for PieceFile {
         for piece in &self.piece_table {
             write!(f, "{}\n", piece);
         }
-        write!(f, "end piece table")
+        write!(f, "end piece table");
+        write!(f, "actions len({})\n", self.actions.len());
+        for action in &self.actions {
+            write!(f, "{}\n", action);
+        }
+        write!(f, "end actions")
     }
 }
 
@@ -622,7 +627,7 @@ impl PieceFile {
             let piece_offset      = piece.logical_offset;
             let piece_length      = piece.length;
 
-            // Unforunately, the easiest way to do this is to read
+            // Unfortunately, the easiest way to do this is to read
             // from the piece and then insert it like we do below.
             self.read_piece(
                 piece,

--- a/src/byt/io/file/mod.rs
+++ b/src/byt/io/file/mod.rs
@@ -649,7 +649,8 @@ impl PieceFile {
     ///
     /// Will do nothing if there is nothing to be undone.
     pub fn undo(&mut self) {
-        if self.actions.len() == 0 {
+        if self.actions.len() == 0 ||
+           self.history_offset == self.actions.len() {
             return;
         }
 

--- a/src/byt/io/file/mod.rs
+++ b/src/byt/io/file/mod.rs
@@ -196,7 +196,7 @@ impl PieceFile {
         if num_pieces > 2 {
             for index in start_index + 1 .. end_index {
                 let piece = &mut self.piece_table[index];
-                action.pieces.push(piece.clone());
+                action.pieces.insert(0, piece.clone());
                 piece.length = 0;
             }
         }
@@ -213,9 +213,9 @@ impl PieceFile {
                 action.merge_up = true;
             }
 
-            action.pieces.push(Piece {
+            action.pieces.insert(0, Piece {
                 file           : piece.file,
-                file_offset    : piece.file_offset + lower_size,
+                file_offset    : piece.file_offset,
                 length         : lower_size,
                 logical_offset : piece_start_offset - lower_size,
             });
@@ -587,6 +587,10 @@ impl PieceFile {
         if action.merge_down && index > 0 {
             self.merge_pieces(index - 1);
         }
+
+        // TODO make this smarter. We really don't have to start
+        // from zero.
+        self.update_offsets(0);
     }
 }
 

--- a/src/byt/io/file/mod.rs
+++ b/src/byt/io/file/mod.rs
@@ -15,6 +15,7 @@ use std::io::Seek;
 use std::io::SeekFrom;
 use std::io;
 use std::str;
+use std::time;
 
 // SUBMODULES
 mod tests;
@@ -83,6 +84,8 @@ struct Action {
     /// merged downwards or upwards when the action is undone.
     merge_down : bool,
     merge_up   : bool,
+    /// The instant this Action was initialized.
+    timestamp : time::Instant,
 }
 
 impl fmt::Display for Action {
@@ -166,6 +169,7 @@ impl PieceFile {
             pieces     : Vec::new(),
             merge_down : false,
             merge_up   : false,
+            timestamp  : time::Instant::now(),
         };
 
         // TODO: ensure we don't overflow
@@ -329,6 +333,7 @@ impl PieceFile {
             // above or below it.
             merge_down : false,
             merge_up   : false,
+            timestamp  : time::Instant::now(),
         };
 
         action.pieces.push(piece.clone());

--- a/src/byt/io/file/tests.rs
+++ b/src/byt/io/file/tests.rs
@@ -238,6 +238,7 @@ fn it_undoes_a_delete_at_the_end_of_a_single_piece() {
     file.undo();
 
     assert_eq!(file.piece_table.len(), 1);
+    assert_eq!(file.piece_table[0].length, 3);
     assert_eq!(file.length, 3);
 
     let read = file.read(3).unwrap();
@@ -254,6 +255,7 @@ fn it_undoes_a_delete_at_the_start_of_a_single_piece() {
     file.undo();
 
     assert_eq!(file.piece_table.len(), 1);
+    assert_eq!(file.piece_table[0].length, 3);
     assert_eq!(file.length, 3);
 
     let read = file.read(3).unwrap();
@@ -307,7 +309,7 @@ fn it_redoes_an_insert() {
     assert_eq!(read.as_str(), "bar");
 }
 
-//#[test]
+#[test]
 fn it_redoes_a_delete() {
     let mut file = PieceFile::empty().unwrap();
     assert_eq!(file.piece_table.len(), 0);
@@ -320,15 +322,13 @@ fn it_redoes_a_delete() {
     assert_eq!(file.length, 2);
 
     file.undo();
-    println!("piece 0 {}", file.piece_table[0]);
-    println!("piece 1 {}", file.piece_table[1]);
     assert_eq!(file.piece_table.len(), 1);
     assert_eq!(file.length, 6);
 
     file.redo();
-    //assert_eq!(file.length, 2);
-    //assert_eq!(file.piece_table.len(), 2);
+    assert_eq!(file.length, 2);
+    assert_eq!(file.piece_table.len(), 1);
 
-    //let read = file.read(2).unwrap();
-    //assert_eq!(read.as_str(), "foar");
+    let read = file.read(2).unwrap();
+    assert_eq!(read.as_str(), "fo");
 }

--- a/src/byt/io/file/tests.rs
+++ b/src/byt/io/file/tests.rs
@@ -117,13 +117,13 @@ fn it_deletes_across_two_pieces() {
     let first_piece = &action.pieces[0];
     assert_eq!(first_piece.file, SourceFile::Append);
     assert_eq!(first_piece.length, 1);
-    assert_eq!(first_piece.file_offset, 5);
+    assert_eq!(first_piece.file_offset, 0);
     assert_eq!(first_piece.logical_offset, 2);
 
     let second_piece = &action.pieces[1];
     assert_eq!(second_piece.file, SourceFile::Append);
     assert_eq!(second_piece.length, 1);
-    assert_eq!(second_piece.file_offset, 1);
+    assert_eq!(second_piece.file_offset, 5);
     assert_eq!(second_piece.logical_offset, 2);
 }
 
@@ -211,6 +211,9 @@ fn it_undoes_a_delete() {
     file.undo();
 
     assert_eq!(file.piece_table.len(), 1);
+
+    let read = file.read(3).unwrap();
+    assert_eq!(read.as_str(), "bar");
 }
 
 #[test]
@@ -221,9 +224,12 @@ fn it_undoes_a_delete_across_two_pieces() {
     file.insert("bar", 0);
     file.insert("foo", 0);
     file.delete(0, 6);
+    assert_eq!(file.piece_table.len(), 0);
     file.undo();
-
     assert_eq!(file.piece_table.len(), 2);
+
+    let read = file.read(6).unwrap();
+    assert_eq!(read.as_str(), "foobar");
 }
 
 #[test]
@@ -238,6 +244,7 @@ fn it_undoes_a_delete_across_three_pieces() {
     file.undo();
 
     assert_eq!(file.piece_table.len(), 3);
+
+    let read = file.read(9).unwrap();
+    assert_eq!(read.as_str(), "carfoobar");
 }
-
-

--- a/src/byt/io/file/tests.rs
+++ b/src/byt/io/file/tests.rs
@@ -362,3 +362,19 @@ fn it_does_not_panic_after_many_redos() {
     file.redo();
     file.redo();
 }
+
+#[test]
+fn it_removes_newer_actions() {
+    let mut file = PieceFile::empty().unwrap();
+    assert_eq!(file.piece_table.len(), 0);
+
+    file.insert("foobar", 0);
+    file.insert("bar", 0);
+    file.undo();
+    file.insert("bar", 0);
+    file.redo();
+
+    let read = file.read(9).unwrap();
+    assert_eq!(read.as_str(), "barfoobar");
+    assert_eq!(file.actions.len(), 2);
+}

--- a/src/byt/io/file/tests.rs
+++ b/src/byt/io/file/tests.rs
@@ -1,4 +1,9 @@
 /// Tests for all buffer operations.
+/// 
+/// Many of these are closer to integration
+/// than unit. Frankly, the idea is to test the
+/// PieceFile's API and whether it performs operations
+/// correctly, not to rigidly test its implementation.
 #[cfg(test)]
 
 use super::*;

--- a/src/byt/io/file/tests.rs
+++ b/src/byt/io/file/tests.rs
@@ -185,6 +185,7 @@ fn it_reads_across_three_pieces() {
     file.insert("bar", 0);
     file.insert("foo", 0);
     file.insert("car", 0);
+
     let read = file.read(9).unwrap();
     assert_eq!(read.as_str(), "carfoobar");
 }

--- a/src/byt/io/file/tests.rs
+++ b/src/byt/io/file/tests.rs
@@ -190,3 +190,54 @@ fn it_reads_across_three_pieces() {
     assert_eq!(read.as_str(), "carfoobar");
 }
 
+#[test]
+fn it_undoes_an_insert() {
+    let mut file = PieceFile::empty().unwrap();
+    assert_eq!(file.piece_table.len(), 0);
+
+    file.insert("bar", 0);
+    file.undo();
+
+    assert_eq!(file.piece_table.len(), 0);
+}
+
+#[test]
+fn it_undoes_a_delete() {
+    let mut file = PieceFile::empty().unwrap();
+    assert_eq!(file.piece_table.len(), 0);
+
+    file.insert("bar", 0);
+    file.delete(1, 1);
+    file.undo();
+
+    assert_eq!(file.piece_table.len(), 1);
+}
+
+#[test]
+fn it_undoes_a_delete_across_two_pieces() {
+    let mut file = PieceFile::empty().unwrap();
+    assert_eq!(file.piece_table.len(), 0);
+
+    file.insert("bar", 0);
+    file.insert("foo", 0);
+    file.delete(0, 6);
+    file.undo();
+
+    assert_eq!(file.piece_table.len(), 2);
+}
+
+#[test]
+fn it_undoes_a_delete_across_three_pieces() {
+    let mut file = PieceFile::empty().unwrap();
+    assert_eq!(file.piece_table.len(), 0);
+
+    file.insert("bar", 0);
+    file.insert("foo", 0);
+    file.insert("car", 0);
+    file.delete(0, 9);
+    file.undo();
+
+    assert_eq!(file.piece_table.len(), 3);
+}
+
+

--- a/src/byt/io/file/tests.rs
+++ b/src/byt/io/file/tests.rs
@@ -332,3 +332,33 @@ fn it_redoes_a_delete() {
     let read = file.read(2).unwrap();
     assert_eq!(read.as_str(), "fo");
 }
+
+#[test]
+fn it_does_not_panic_after_many_undos() {
+    let mut file = PieceFile::empty().unwrap();
+    assert_eq!(file.piece_table.len(), 0);
+
+    file.insert("foobar", 0);
+    assert_eq!(file.piece_table.len(), 1);
+
+    file.undo();
+    file.undo();
+    file.undo();
+    file.undo();
+    file.undo();
+}
+
+#[test]
+fn it_does_not_panic_after_many_redos() {
+    let mut file = PieceFile::empty().unwrap();
+    assert_eq!(file.piece_table.len(), 0);
+
+    file.insert("foobar", 0);
+    assert_eq!(file.piece_table.len(), 1);
+
+    file.undo();
+    file.redo();
+    file.redo();
+    file.redo();
+    file.redo();
+}


### PR DESCRIPTION
Each insert and delete leaves behind an action on the PieceFile's stack that can be undone with `PieceFile.undo()`. We want to support `PieceFile.redo()` in the future that allows moving forwards in time, too. As soon as the user performs an insert or delete, the history ahead of the current table is deleted. E.g if the user goes back a few edits and inserts some text, they cannot recover the edits they undid.

Ideally this branch also provides vim-style `earlier` and `later` methods that allow the user to go forwards and backwards in time.