### PR TITLE
Improve bindings and mutations of state

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,11 @@ being functional. The roadmap is as follows:
   every event.
 - [X] Create a FileView that acts as a viewport into a PieceFile. Manages all
   aspects of reading, writing, and creating files.
-- [ ] byt should have a system similar to emacs where action identifiers are a
-  first-class citizen. All keybindings that correspond to an action really are
-  calling a function by name. Come up with the system of scoping (i.e pane
-  specific, global, etc) and passing mutable editor state into the functions.
+- [X] All keybindings that correspond to an action really are calling a
+  function by name. Come up with the system of scoping (i.e pane specific,
+  global, etc) and passing mutable editor state into the functions.
+- [X] Give the aforementioned closures a way to store and retrieve arbitrary
+  state.
 - [ ] Implement `vym`, byt's vim emulation mode. Most movement and insertion
   bindings will be supported out of the box.
 - [ ] Include Lua for editor extensibility. The MVP is that functions defined

--- a/src/byt/editor/mod.rs
+++ b/src/byt/editor/mod.rs
@@ -9,6 +9,7 @@ use std::io;
 
 // SUBMODULES
 mod mutator;
+mod tests;
 
 // LOCAL INCLUDES
 use byt::views::file::FileView;

--- a/src/byt/editor/mod.rs
+++ b/src/byt/editor/mod.rs
@@ -59,6 +59,9 @@ pub struct Editor {
     /// been consumed yet.
     actions : Vec<Action>,
 
+    /// All of the global mutators for the editor.
+    mutators : Vec<Box<mutator::Mutator<Editor>>>,
+
     /// Whether or not we should render at the next opportunity.
     should_render : bool,
 }
@@ -70,6 +73,7 @@ impl Editor {
             keys  : Keymaster::new(),
             current_file : 0,
             should_render : false,
+            mutators : Vec::new(),
             actions : Vec::new(),
         }
     }
@@ -120,5 +124,12 @@ impl Actionable for Editor {
 
     fn has_action(&self) -> bool {
         self.actions.len() > 0
+    }
+}
+
+impl mutator::Mutatable<Editor> for Editor {
+    fn register_mutator(&mut self, mutator : Box<mutator::Mutator<Editor>>) -> io::Result<()> {
+        self.mutators.push(mutator);
+        Ok(())
     }
 }

--- a/src/byt/editor/mod.rs
+++ b/src/byt/editor/mod.rs
@@ -23,8 +23,8 @@ use byt::render;
 pub struct Action {
 }
 
-/// Allows for the entity to produce Actions to be executed. 
-/// Similar to rendering, actions are 
+/// Allows for the entity to produce Actions to be executed.
+/// Similar to rendering, actions are
 pub trait Actionable {
     /// Pop an action off of the action stack.
     fn grab_action(&mut self) -> Option<Action>;
@@ -34,7 +34,7 @@ pub trait Actionable {
 }
 
 /// Contains all editor state, responds to user input, and
-/// renders appropriately. 
+/// renders appropriately.
 pub struct Editor {
     /// Akin to vim's buffers. All of the open files in the editor.
     files : Vec<FileView>,

--- a/src/byt/editor/mod.rs
+++ b/src/byt/editor/mod.rs
@@ -5,12 +5,14 @@
 
 // LIBRARY INCLUDES
 use termion::event::Key;
+use std::io;
 
 // SUBMODULES
 
 // LOCAL INCLUDES
 use byt::views::file::FileView;
 use byt::io::binds::{Keymaster, KeyInput};
+use byt::render;
 
 #[derive(Clone, PartialEq, Debug)]
 /// Represents a mutation of the editing state. Actions are guaranteed to execute in order, with
@@ -45,6 +47,9 @@ pub struct Editor {
     /// Stores any action that we've generated but hasn't
     /// been consumed yet.
     actions : Vec<Action>,
+
+    /// Whether or not we should render at the next opportunity.
+    should_render : bool,
 }
 
 impl Editor {
@@ -53,6 +58,7 @@ impl Editor {
             files : Vec::new(),
             keys  : Keymaster::new(),
             current_file : 0,
+            should_render : false,
             actions : Vec::new(),
         }
     }
@@ -66,6 +72,16 @@ impl KeyInput for Editor {
     fn consume(&mut self, key : Key) -> Option<()> {
         // TODO: do it pane-locally first
         self.keys.consume(key)
+    }
+}
+
+impl render::Renderable for Editor {
+    fn render(&mut self, renderer : &mut render::Renderer, size : (u16, u16)) -> io::Result<()> {
+        self.current_file().unwrap().render(renderer, size)
+    }
+
+    fn should_render(&self) -> bool {
+        self.should_render
     }
 }
 

--- a/src/byt/editor/mod.rs
+++ b/src/byt/editor/mod.rs
@@ -100,7 +100,7 @@ impl KeyInput for Editor {
                 return Some(());
             }
         }
-            
+
         self.keys.consume(key)
     }
 }

--- a/src/byt/editor/mod.rs
+++ b/src/byt/editor/mod.rs
@@ -8,6 +8,7 @@ use termion::event::Key;
 use std::io;
 
 // SUBMODULES
+mod mutator;
 
 // LOCAL INCLUDES
 use byt::views::file::FileView;

--- a/src/byt/editor/mod.rs
+++ b/src/byt/editor/mod.rs
@@ -19,6 +19,7 @@ mod tests;
 use byt::views::file::FileView;
 use byt::io::binds::{Keymaster, KeyInput};
 use byt::render;
+use byt::editor::mutator::Scope;
 
 #[derive(Clone, PartialEq, Debug)]
 /// An action will try to run the function in the scope specified.
@@ -115,11 +116,7 @@ impl Actionable for Editor {
     }
 
     fn perform_action(&mut self, action : Action) -> io::Result<()> {
-        if let Action::Editor(name) = action {
-            return Ok(());
-        }
-
-        return Err(Error::new(ErrorKind::InvalidInput, "Wrong entity"));
+        Ok(())
     }
 
     fn has_action(&self) -> bool {

--- a/src/byt/editor/mod.rs
+++ b/src/byt/editor/mod.rs
@@ -63,8 +63,16 @@ impl Editor {
         }
     }
 
+    /// Get the file that's currently open.
     pub fn current_file(&mut self) -> Option<&mut FileView> {
         self.files.get_mut(self.current_file)
+    }
+
+    /// Attempt to open a file and make it the current pane.
+    pub fn open(&mut self, path : &str) -> io::Result<()> {
+        self.files.push(FileView::new(path)?);
+        self.current_file = self.files.len() - 1;
+        Ok(())
     }
 }
 
@@ -81,7 +89,8 @@ impl render::Renderable for Editor {
     }
 
     fn should_render(&self) -> bool {
-        self.should_render
+        // TODO This is dangerous. Fix this.
+        self.files[self.current_file].should_render()
     }
 }
 

--- a/src/byt/editor/mod.rs
+++ b/src/byt/editor/mod.rs
@@ -1,0 +1,59 @@
+//! byt - editor
+//!
+//! Everything relating to editor state.
+// EXTERNS
+
+// LIBRARY INCLUDES
+use termion::event::Key;
+
+// SUBMODULES
+
+// LOCAL INCLUDES
+use byt::views::file::FileView;
+use byt::io::binds::Keymaster;
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct Action {
+}
+
+pub struct Editor {
+    /// Akin to vim's buffers. All the open files in the editor.
+    files : Vec<FileView>,
+
+    /// Stores all of the global keybindings.
+    keys : Keymaster,
+
+    /// The index of the current file.
+    current_file : usize,
+
+    /// Stores any action that we've generated but hasn't
+    /// been consumed yet.
+    actions : Vec<Action>,
+}
+
+impl Editor {
+    pub fn new() -> Editor {
+        Editor {
+            files : Vec::new(),
+            keys  : Keymaster::new(),
+            current_file : 0,
+            actions : Vec::new(),
+        }
+    }
+
+    /// Consume a key of input.
+    pub fn consume(&mut self, key : Key) -> Option<()> {
+        // TODO: do it pane-locally first
+        self.keys.consume(key)
+    }
+
+    /// Pop an action off the stack.
+    pub fn grab_action(&mut self) -> Option<Action> {
+        self.actions.pop()
+    }
+
+    /// Check whether there is an action to be consumed.
+    pub fn has_action(&self) -> bool {
+        self.actions.len() > 0
+    }
+}

--- a/src/byt/editor/mod.rs
+++ b/src/byt/editor/mod.rs
@@ -10,9 +10,10 @@ use std::io::{
     Error,
     ErrorKind
 };
+use std::vec::Drain;
 
 // SUBMODULES
-mod mutator;
+pub mod mutator;
 mod tests;
 
 // LOCAL INCLUDES
@@ -30,17 +31,9 @@ pub enum Action {
 }
 
 /// Allows for the entity to produce Actions to be executed.
-/// Similar to rendering, actions are
 pub trait Actionable {
-    /// Pop an action off of the action stack.
-    fn grab_action(&mut self) -> Option<Action>;
-
-    /// Attempt to perform the action. Will error if the Action is
-    /// of an invalid type for this entity.
-    fn perform_action(&mut self, action : Action) -> io::Result<()>;
-
-    /// Check whether there is an action that can be handled.
-    fn has_action(&self) -> bool;
+    /// All of the actions that have not yet been consumed.
+    fn actions(&mut self) -> Vec<Action>;
 }
 
 /// Contains all editor state, responds to user input, and
@@ -111,16 +104,8 @@ impl render::Renderable for Editor {
 }
 
 impl Actionable for Editor {
-    fn grab_action(&mut self) -> Option<Action> {
-        self.actions.pop()
-    }
-
-    fn perform_action(&mut self, action : Action) -> io::Result<()> {
-        Ok(())
-    }
-
-    fn has_action(&self) -> bool {
-        self.actions.len() > 0
+    fn actions(&mut self) -> Vec<Action> {
+        self.actions.drain(..).collect()
     }
 }
 

--- a/src/byt/editor/mutator.rs
+++ b/src/byt/editor/mutator.rs
@@ -30,13 +30,13 @@ pub trait Scope<S, T> {
 /// Each closure is given a mutable reference to some kind of state storage
 /// (usually a struct or even the mutator itself) and the closure's target,
 /// which would be something like the editor or a pane.
-pub struct RustMutator<'a, S, T> {
+pub struct RustScope<'a, S, T> {
     map : HashMap<String, Box<Fn(&mut S, &mut T) + 'a>>
 }
 
-impl<'a, S, T> RustMutator<'a, S, T> {
-    pub fn new() -> RustMutator<'a, S, T> {
-        RustMutator {
+impl<'a, S, T> RustScope<'a, S, T> {
+    pub fn new() -> RustScope<'a, S, T> {
+        RustScope {
             map : HashMap::new()
         }
     }
@@ -47,7 +47,7 @@ impl<'a, S, T> RustMutator<'a, S, T> {
     }
 }
 
-impl<'a, S, T> Scope<S, T> for RustMutator<'a, S, T> {
+impl<'a, S, T> Scope<S, T> for RustScope<'a, S, T> {
     fn call(&self, name : &str, state : &mut S, target : &mut T) -> io::Result<()> {
         let closure = self.map.get(name);
 

--- a/src/byt/editor/mutator.rs
+++ b/src/byt/editor/mutator.rs
@@ -1,0 +1,59 @@
+//! byt - editor::mutator
+//!
+//! Provides abstractions over making modifications to editor state.
+//! See the documentation for `Mutator`.
+
+// EXTERNS
+
+// LIBRARY INCLUDES
+use std::collections::HashMap;
+use std::io::{
+    Error,
+    ErrorKind
+};
+use std::io;
+
+// SUBMODULES
+
+// LOCAL INCLUDES
+
+/// Defines a way of calling some function by its identifier
+/// within a given scope. The closure is given a mutable reference
+/// to something of the Scope's type.
+trait Scope<T> {
+    /// Perform the function referred to by `name` on the mutable target.
+    /// Will error if the name has no association.
+    fn call(&self, name : &str, target : &mut T) -> io::Result<()>;
+}
+
+/// Stores and allows the invocation of any procedures defined in Rust.
+struct RustMutator<'a, T> {
+    map : HashMap<String, Box<Fn(&mut T) + 'a>>
+}
+
+impl<'a, T> RustMutator<'a, T> {
+    fn new() -> RustMutator<'a, T> {
+        RustMutator {
+            map : HashMap::new()
+        }
+    }
+
+    /// Register a closure with a name.
+    fn register<F: Fn(&mut T) + 'a>(&mut self, name: String, closure: F) {
+        self.map.insert(name, Box::new(closure) as Box<Fn(&mut T) + 'a>);
+    }
+}
+
+impl<'a, T> Scope<T> for RustMutator<'a, T> {
+    fn call(&self, name : &str, target : &mut T) -> io::Result<()> {
+        let closure = self.map.get(name);
+
+        if closure.is_none() {
+            return Err(Error::new(ErrorKind::InvalidInput, "Closure not found for name"));
+        }
+
+        closure.unwrap()(target);
+
+        Ok(())
+    }
+}

--- a/src/byt/editor/mutator.rs
+++ b/src/byt/editor/mutator.rs
@@ -20,41 +20,42 @@ use std::io;
 /// Defines a way of calling some function by its identifier
 /// within a given scope. The closure is given a mutable reference
 /// to something of the Scope's type.
-pub trait Scope<T> {
+pub trait Scope<S, T> {
     /// Perform the function referred to by `name` on the mutable target.
     /// Will error if the name has no association.
-    fn call(&self, name : &str, target : &mut T) -> io::Result<()>;
+    fn call(&self, name : &str, state : &mut S, target : &mut T) -> io::Result<()>;
 }
 
 /// Stores and allows the invocation of any procedures defined in Rust.
-/// The lifetime here allows the closures to use things in their parent
-/// stacks.
-pub struct RustMutator<'a, T> {
-    map : HashMap<String, Box<Fn(&mut T) + 'a>>
+/// Each closure is given a mutable reference to some kind of state storage
+/// (usually a struct or even the mutator itself) and the closure's target,
+/// which would be something like the editor or a pane.
+pub struct RustMutator<'a, S, T> {
+    map : HashMap<String, Box<Fn(&mut S, &mut T) + 'a>>
 }
 
-impl<'a, T> RustMutator<'a, T> {
-    pub fn new() -> RustMutator<'a, T> {
+impl<'a, S, T> RustMutator<'a, S, T> {
+    pub fn new() -> RustMutator<'a, S, T> {
         RustMutator {
             map : HashMap::new()
         }
     }
 
     /// Register a closure with a name.
-    pub fn register<F: Fn(&mut T) + 'a, S: AsRef<str>>(&mut self, name: S, closure: F) {
-        self.map.insert(String::from(name.as_ref()), Box::new(closure) as Box<Fn(&mut T) + 'a>);
+    pub fn register<F: Fn(&mut S, &mut T) + 'a, N: AsRef<str>>(&mut self, name: N, closure: F) {
+        self.map.insert(String::from(name.as_ref()), Box::new(closure) as Box<Fn(&mut S, &mut T) + 'a>);
     }
 }
 
-impl<'a, T> Scope<T> for RustMutator<'a, T> {
-    fn call(&self, name : &str, target : &mut T) -> io::Result<()> {
+impl<'a, S, T> Scope<S, T> for RustMutator<'a, S, T> {
+    fn call(&self, name : &str, state : &mut S, target : &mut T) -> io::Result<()> {
         let closure = self.map.get(name);
 
         if closure.is_none() {
             return Err(Error::new(ErrorKind::InvalidInput, "Closure not found for name"));
         }
 
-        closure.unwrap()(target);
+        closure.unwrap()(state, target);
 
         Ok(())
     }

--- a/src/byt/editor/mutator.rs
+++ b/src/byt/editor/mutator.rs
@@ -72,4 +72,11 @@ impl<'a, S, T> Scope<T> for RustScope<'a, S, T> {
 
 /// A Mutator describes a set of bindings, actions, and hooks that manipulate a n instance of a
 /// type in some way.
-trait Mutator<T>: KeyInput + Actionable + Scope<T> {}
+pub trait Mutator<T>: KeyInput + Actionable + Scope<T> {}
+
+/// A characteristic of an entity that allows state manipulation with mutators.
+/// The degree to which mutators are used is up to the implementer.
+pub trait Mutatable<T> {
+    /// Register a mutator with this entity.
+    fn register_mutator(&mut self, mutator : Box<Mutator<T>>) -> io::Result<()>;
+}

--- a/src/byt/editor/mutator.rs
+++ b/src/byt/editor/mutator.rs
@@ -87,7 +87,10 @@ impl<'a, S, T> Scope<T> for RustScope<'a, S, T> {
 
 /// A Mutator describes a set of bindings, actions, and hooks that manipulate a n instance of a
 /// type in some way.
-pub trait Mutator<T>: KeyInput + Actionable + Scope<T> + Renderable {}
+pub trait Mutator<T>: KeyInput + Actionable + Scope<T> + Renderable {
+    ///// Called after the mutator is registered on an entity.
+    //fn post_register(&mut self, target : &mut T) -> io::Result<()>;
+}
 
 /// A characteristic of an entity that allows state manipulation with mutators.
 /// The degree to which mutators are used is up to the implementer.

--- a/src/byt/editor/mutator.rs
+++ b/src/byt/editor/mutator.rs
@@ -99,13 +99,13 @@ pub trait Mutatable<T> {
     fn register_mutator(&mut self, mutator : Box<Mutator<T>>) -> io::Result<()>;
 }
 
-pub struct MutatePair<T> 
+pub struct MutatePair<T>
     where T: KeyInput + Actionable + Renderable {
     mutators : Vec<Box<Mutator<T>>>,
     target : T,
 }
 
-impl<T> MutatePair<T> 
+impl<T> MutatePair<T>
     where T: KeyInput + Actionable + Renderable {
 
     /// Make a new MutatePair by sacrificing an instance of the pair's type.
@@ -135,7 +135,7 @@ impl<T> MutatePair<T>
     }
 }
 
-impl<T> KeyInput for MutatePair<T> 
+impl<T> KeyInput for MutatePair<T>
     where T: KeyInput + Actionable + Renderable {
     fn consume(&mut self, key : Key) -> Option<()> {
         for mutator in self.mutators.iter_mut() {
@@ -148,7 +148,7 @@ impl<T> KeyInput for MutatePair<T>
     }
 }
 
-impl<T> Actionable for MutatePair<T> 
+impl<T> Actionable for MutatePair<T>
     where T: KeyInput + Actionable + Renderable {
     fn actions(&mut self) -> Vec<Action> {
         let mut actions = Vec::new();
@@ -167,7 +167,7 @@ impl<T> Actionable for MutatePair<T>
     }
 }
 
-impl<T> Renderable for MutatePair<T> 
+impl<T> Renderable for MutatePair<T>
     where T: KeyInput + Actionable + Renderable {
     fn render(&mut self, renderer : &mut render::Renderer, size : (u16, u16)) -> io::Result<()> {
         self.target.render(renderer, size);

--- a/src/byt/editor/mutator.rs
+++ b/src/byt/editor/mutator.rs
@@ -20,27 +20,29 @@ use std::io;
 /// Defines a way of calling some function by its identifier
 /// within a given scope. The closure is given a mutable reference
 /// to something of the Scope's type.
-trait Scope<T> {
+pub trait Scope<T> {
     /// Perform the function referred to by `name` on the mutable target.
     /// Will error if the name has no association.
     fn call(&self, name : &str, target : &mut T) -> io::Result<()>;
 }
 
 /// Stores and allows the invocation of any procedures defined in Rust.
-struct RustMutator<'a, T> {
+/// The lifetime here allows the closures to use things in their parent
+/// stacks.
+pub struct RustMutator<'a, T> {
     map : HashMap<String, Box<Fn(&mut T) + 'a>>
 }
 
 impl<'a, T> RustMutator<'a, T> {
-    fn new() -> RustMutator<'a, T> {
+    pub fn new() -> RustMutator<'a, T> {
         RustMutator {
             map : HashMap::new()
         }
     }
 
     /// Register a closure with a name.
-    fn register<F: Fn(&mut T) + 'a>(&mut self, name: String, closure: F) {
-        self.map.insert(name, Box::new(closure) as Box<Fn(&mut T) + 'a>);
+    pub fn register<F: Fn(&mut T) + 'a, S: AsRef<str>>(&mut self, name: S, closure: F) {
+        self.map.insert(String::from(name.as_ref()), Box::new(closure) as Box<Fn(&mut T) + 'a>);
     }
 }
 

--- a/src/byt/editor/tests.rs
+++ b/src/byt/editor/tests.rs
@@ -1,0 +1,18 @@
+/// Tests for all of the fun editor stuff.
+#[cfg(test)]
+
+use super::*;
+use super::mutator::Scope;
+
+#[test]
+fn it_uses_a_rust_closure() {
+    let mut bar = 0;
+    let mut rust = mutator::RustMutator::new();
+
+    rust.register("foo", |a| {
+        *a = 2;
+    });
+
+    rust.call("foo", &mut bar);
+    assert_eq!(bar, 2);
+}

--- a/src/byt/editor/tests.rs
+++ b/src/byt/editor/tests.rs
@@ -6,13 +6,28 @@ use super::mutator::Scope;
 
 #[test]
 fn it_uses_a_rust_closure() {
+    let mut foo = 0;
     let mut bar = 0;
     let mut rust = mutator::RustMutator::new();
 
-    rust.register("foo", |a| {
-        *a = 2;
+    rust.register("foo", |state, target| {
+        *target = 2;
     });
 
-    rust.call("foo", &mut bar);
+    rust.call("foo", &mut foo, &mut bar);
     assert_eq!(bar, 2);
+}
+
+#[test]
+fn it_uses_a_rust_closure_with_state() {
+    let mut foo = false;
+    let mut bar = 0;
+    let mut rust = mutator::RustMutator::new();
+
+    rust.register("foo", |state, target| {
+        *state = true;
+    });
+
+    rust.call("foo", &mut foo, &mut bar);
+    assert!(foo);
 }

--- a/src/byt/editor/tests.rs
+++ b/src/byt/editor/tests.rs
@@ -6,28 +6,26 @@ use super::mutator::Scope;
 
 #[test]
 fn it_uses_a_rust_closure() {
-    let mut foo = 0;
     let mut bar = 0;
-    let mut rust = mutator::RustScope::new();
+    let mut rust = mutator::RustScope::new(0);
 
     rust.register("foo", |state, target| {
         *target = 2;
     });
 
-    rust.call("foo", &mut foo, &mut bar);
+    rust.call("foo", &mut bar);
     assert_eq!(bar, 2);
 }
 
 #[test]
 fn it_uses_a_rust_closure_with_state() {
-    let mut foo = false;
     let mut bar = 0;
-    let mut rust = mutator::RustScope::new();
+    let mut rust = mutator::RustScope::new(false);
 
     rust.register("foo", |state, target| {
         *state = true;
     });
 
-    rust.call("foo", &mut foo, &mut bar);
-    assert!(foo);
+    rust.call("foo", &mut bar);
+    assert!(*rust.get_state());
 }

--- a/src/byt/editor/tests.rs
+++ b/src/byt/editor/tests.rs
@@ -8,7 +8,7 @@ use super::mutator::Scope;
 fn it_uses_a_rust_closure() {
     let mut foo = 0;
     let mut bar = 0;
-    let mut rust = mutator::RustMutator::new();
+    let mut rust = mutator::RustScope::new();
 
     rust.register("foo", |state, target| {
         *target = 2;
@@ -22,7 +22,7 @@ fn it_uses_a_rust_closure() {
 fn it_uses_a_rust_closure_with_state() {
     let mut foo = false;
     let mut bar = 0;
-    let mut rust = mutator::RustMutator::new();
+    let mut rust = mutator::RustScope::new();
 
     rust.register("foo", |state, target| {
         *state = true;

--- a/src/byt/events.rs
+++ b/src/byt/events.rs
@@ -8,10 +8,11 @@ use termion::event::Key;
 // SUBMODULES
 
 // LOCAL INCLUDES
+use byt::editor::Action;
 
 pub enum Event {
     /// An action that should be handled.
-    Function(String),
+    Function(Action),
     /// Any keypress registered by stdio.
     KeyPress(Key)
 }

--- a/src/byt/events.rs
+++ b/src/byt/events.rs
@@ -11,8 +11,7 @@ use termion::event::Key;
 use byt::editor::Action;
 
 pub enum Event {
-    /// An action that should be handled.
-    Function(Action),
     /// Any keypress registered by stdio.
-    KeyPress(Key)
+    KeyPress(Key),
+    Nothing
 }

--- a/src/byt/io/binds/mod.rs
+++ b/src/byt/io/binds/mod.rs
@@ -233,6 +233,18 @@ impl Keymaster {
     // P U B L I C  F U N C T I O N S
     // ###############################
 
+    /// Bind some an action to a key sequence. Intermediate binding
+    /// tables are created automatically. Will return Err if the sequence
+    /// does not resolve to a table that can be created. This might happen
+    /// if you try to bind `Ctrl+a b` to something and `Ctrl+a` is already
+    /// bound to something that's not a table.
+    pub fn bind<T: AsRef<[Key]>>(&mut self, sequence : T, action : Arrow) -> io::Result<()> {
+        let sequence       = sequence.as_ref();
+        let (prefix, last) = sequence.split_at(sequence.len() - 1);
+        let table          = self.make_prefix(sequence)?;
+
+        self.get_table_by_id(table).unwrap().bind(last[0], action)
+    }
 
     /// Get an arrow (a binding) from a sequence of keys.
     /// We say `arrow` here because this might not be a "leaf node",

--- a/src/byt/io/binds/mod.rs
+++ b/src/byt/io/binds/mod.rs
@@ -16,10 +16,7 @@ mod tests;
 
 // LOCAL INCLUDES
 
-/// Stores some information about what should be done when
-/// the state machine reaches this state. It's called an arrow
-/// because it refers to the next state, even if that involves
-/// sending an action up to the editor as a result.
+/// Acts as a transition arrow between states of the state machine. 
 #[derive(Clone, PartialEq, Debug)]
 enum Arrow {
     /// Triggers some kind of action within the editor.

--- a/src/byt/io/binds/mod.rs
+++ b/src/byt/io/binds/mod.rs
@@ -175,6 +175,12 @@ pub struct Keymaster {
     /// The root table with id 0.
     root_table : BindingTable,
 
+    // TODO: Make the Keymaster use a HashMap instead.
+    // The current approach works more or less without problems,
+    // but it's effectively a reimplementation of a hash map except
+    // with monotonically nondecreasing ids assigned to every
+    // new table. Just because it works and is simple doesn't mean
+    // it's good.
     /// All other binding tables. They are referred to by
     /// their id.
     tables : Vec<BindingTable>,

--- a/src/byt/io/binds/mod.rs
+++ b/src/byt/io/binds/mod.rs
@@ -392,6 +392,8 @@ impl Keymaster {
             }
         }
 
+        // TODO clear out empty tables
+
         Ok(())
     }
 

--- a/src/byt/io/binds/mod.rs
+++ b/src/byt/io/binds/mod.rs
@@ -15,7 +15,7 @@ use std::io;
 mod tests;
 
 // LOCAL INCLUDES
-use byt::editor::Action;
+use byt::editor::{Action, Actionable};
 
 /// Acts as a transition arrow between states of the state machine.
 #[derive(Clone, PartialEq, Debug)]
@@ -33,6 +33,13 @@ enum Arrow {
 
     /// Stay in the current table and do nothing.
     Nothing
+}
+
+pub trait KeyInput {
+    /// Handle a key of new user input. If the key got consumed
+    /// (i.e resulted in a state transition of some sort) then
+    /// this method will return Some.
+    fn consume(&mut self, key : Key) -> Option<()>;
 }
 
 /// The association of a key to some action.
@@ -226,28 +233,6 @@ impl Keymaster {
     // P U B L I C  F U N C T I O N S
     // ###############################
 
-    /// Handle a key of new user input. If the key got consumed
-    /// (i.e resulted in a state transition of some sort) then
-    /// this method will return Some.
-    pub fn consume(&mut self, key : Key) -> Option<()> {
-        let mut action : Arrow;
-
-        // I kind of hate the fact that I have to clone
-        // the result, but it's a product of Rust's sensible
-        // rules wherein you can't have multiple mutable/immutable
-        // references at once.
-        {
-            let result = self.search_key(key);
-
-            if result.is_none() {
-                return None
-            }
-
-            action = (*result.unwrap()).clone();
-        }
-
-        self.handle_action(&action)
-    }
 
     /// Get an arrow (a binding) from a sequence of keys.
     /// We say `arrow` here because this might not be a "leaf node",
@@ -388,5 +373,27 @@ impl Keymaster {
             id_counter : 1,
             actions : Vec::new()
         }
+    }
+}
+
+impl KeyInput for Keymaster {
+    fn consume(&mut self, key : Key) -> Option<()> {
+        let mut action : Arrow;
+
+        // I kind of hate the fact that I have to clone
+        // the result, but it's a product of Rust's sensible
+        // rules wherein you can't have multiple mutable/immutable
+        // references at once.
+        {
+            let result = self.search_key(key);
+
+            if result.is_none() {
+                return None
+            }
+
+            action = (*result.unwrap()).clone();
+        }
+
+        self.handle_action(&action)
     }
 }

--- a/src/byt/io/binds/mod.rs
+++ b/src/byt/io/binds/mod.rs
@@ -249,10 +249,10 @@ impl Keymaster {
         self.get_table_by_id(0).unwrap()
     }
 
-    /// Get a binding table according to a sequence of keys, which
+    /// Get a binding table according to a prefix of keys, which
     /// are evaluated starting at the root. Will only return Some
     /// if the keys evaluate to a state that is a table.
-    pub fn get_table<T: AsRef<[Key]>>(&mut self, sequence : T) -> Option<&mut BindingTable> {
+    pub fn get_prefix<T: AsRef<[Key]>>(&mut self, sequence : T) -> Option<&mut BindingTable> {
         let mut id = 0;
 
         for key in sequence.as_ref().iter() {

--- a/src/byt/io/binds/mod.rs
+++ b/src/byt/io/binds/mod.rs
@@ -15,6 +15,7 @@ use termion::event::Key;
 /// the state machine reaches this state. It's called an arrow
 /// because it refers to the next state, even if that involves
 /// sending an action up to the editor as a result.
+#[derive(Clone)]
 pub enum Arrow {
     /// Triggers some kind of action within the editor.
     /// In the future this will be a reference to a closure, probably.
@@ -203,9 +204,27 @@ impl Keymaster {
         }
     }
 
+    fn search_key(&self, key : Key) -> Option<&Arrow> {
+        self.get_state().search_key(key)
+    }
+
     /// Handle a key of new user input.
     pub fn consume(&mut self, key : Key) -> Option<String> {
-        let mut action : Arrow = Arrow::Nothing;
+        let mut action : Arrow;
+
+        // I kind of hate the fact that I have to clone
+        // the result, but it's a product of Rust's sensible
+        // rules wherein you can't have multiple mutable/immutable
+        // references at once.
+        {
+            let result = self.search_key(key);
+
+            if result.is_none() {
+                return None
+            }
+
+            action = (*result.unwrap()).clone();
+        }
 
         return self.handle_action(&action);
     }

--- a/src/byt/io/binds/mod.rs
+++ b/src/byt/io/binds/mod.rs
@@ -244,9 +244,19 @@ impl Keymaster {
         return self.handle_action(&action);
     }
 
-    /// Get the root binding table.
-    pub fn get_root(&mut self) -> &mut BindingTable {
-        self.get_table_by_id(0).unwrap()
+    /// Get an arrow (a binding) from a sequence of keys.
+    /// We say `arrow` here because this might not be a "leaf node",
+    /// or an action that results in returning to the root table.
+    pub fn get_arrow<T: AsRef<[Key]>>(&mut self, sequence : T) -> Option<&Arrow> {
+        let sequence       = sequence.as_ref();
+        let (prefix, last) = sequence.split_at(sequence.len() - 1);
+        let table          = self.get_prefix(prefix);
+
+        if table.is_none() {
+            return None;
+        }
+
+        table.unwrap().search_key(last[0])
     }
 
     /// Get a binding table according to a prefix of keys, which
@@ -278,6 +288,11 @@ impl Keymaster {
         }
 
         self.get_table_by_id(id)
+    }
+
+    /// Get the root binding table.
+    pub fn get_root(&mut self) -> &mut BindingTable {
+        self.get_table_by_id(0).unwrap()
     }
 
     /// Make a new table at the end of a prefix of keys. If the arrows

--- a/src/byt/io/binds/mod.rs
+++ b/src/byt/io/binds/mod.rs
@@ -7,7 +7,7 @@
 use termion::event::Key;
 
 // SUBMODULES
-mod tests;
+//mod tests;
 
 // LOCAL INCLUDES
 
@@ -77,6 +77,17 @@ impl BindingTable {
     // P U B L I C  F U N C T I O N S
     // ###############################
 
+    /// Add a binding to the table.
+    pub fn add_binding(&mut self, binding : Binding) {
+        self.ensure_unique(binding.key);
+        self.bindings.push(binding);
+    }
+
+    /// Get this BindingTable's unique id.
+    pub fn get_id(&self) -> usize {
+        self.id
+    }
+
     /// Make a new BindingTable without anything in it.
     pub fn new(id : usize) -> BindingTable {
         BindingTable {
@@ -84,17 +95,6 @@ impl BindingTable {
             wildcard : Arrow::Nothing,
             id,
         }
-    }
-
-    /// Add a binding to the table.
-    pub fn add_binding(&mut self, binding : Binding) {
-        self.ensure_unique(binding.key);
-        self.bindings.push(binding);
-    }
-
-    /// Set the wildcard action.
-    pub fn set_wildcard(&mut self, action : Arrow) {
-        self.wildcard = action;
     }
 
     /// Look through the table for any entries that match
@@ -114,6 +114,11 @@ impl BindingTable {
         }
 
         Some(&entry.unwrap().result)
+    }
+
+    /// Set the wildcard action.
+    pub fn set_wildcard(&mut self, action : Arrow) {
+        self.wildcard = action;
     }
 }
 
@@ -159,8 +164,17 @@ impl Keymaster {
     /// was called, return its identifier.
     fn handle_action(&mut self, next : &Arrow) -> Option<String> {
         match *next {
-            Arrow::Function(ref action) => {},
-            Arrow::Table(ref table) => {},
+            Arrow::Function(ref action) => {
+                return Some(action.clone());
+            },
+            // Move to the table's state.
+            Arrow::Table(ref table) => {
+                let id = *table;
+
+                if let Some(_) = self.get_table(id) {
+                    self.current_table = id;
+                }
+            },
             Arrow::Nothing => {}
         }
 
@@ -172,23 +186,6 @@ impl Keymaster {
         self.tables.push(BindingTable::new(self.id_counter));
         self.id_counter += 1;
         self.get_table(self.id_counter - 1).unwrap()
-    }
-
-    /// Search through the tables in the Keymaster for a binding
-    /// that matches a key.
-    fn search_key(&mut self, key : Key) -> Option<&Arrow> {
-        let mut action : Option<&Arrow> = Option::None;
-
-        // Start from the top of the stack and go down.
-        //for table in self.tables.iter().rev() {
-        //action = table.search_key(key);
-
-        //if action.is_some() {
-        //break
-        //}
-        //}
-
-        action
     }
 
     // ###############################

--- a/src/byt/io/binds/mod.rs
+++ b/src/byt/io/binds/mod.rs
@@ -5,6 +5,11 @@
 
 // LIBRARY INCLUDES
 use termion::event::Key;
+use std::io::{
+    Error,
+    ErrorKind
+};
+use std::io;
 
 // SUBMODULES
 //mod tests;
@@ -16,7 +21,7 @@ use termion::event::Key;
 /// because it refers to the next state, even if that involves
 /// sending an action up to the editor as a result.
 #[derive(Clone)]
-pub enum Arrow {
+enum Arrow {
     /// Triggers some kind of action within the editor.
     /// In the future this will be a reference to a closure, probably.
     /// For now we just use strings for ease of testing.
@@ -50,7 +55,7 @@ impl Binding {
 }
 
 /// A table of bindings.
-pub struct BindingTable {
+struct BindingTable {
     bindings : Vec<Binding>,
     /// Describes what happens when a key matches nothing in the list
     /// of bindings. If `wildcard` is an Arrow, it is invoked with
@@ -65,31 +70,41 @@ impl BindingTable {
     // #################################
     // P R I V A T E  F U N C T I O N S
     // #################################
+
     /// Make sure that a binding does not conflict with other bindings
     /// in the table.
-    fn ensure_unique(&self, key : Key) {
+    fn ensure_unique(&self, key : Key) -> io::Result<()> {
         for binding in self.bindings.iter() {
             if key != binding.key {
                 continue;
             }
 
-            panic!("Binding already exists for key");
+            return Err(Error::new(ErrorKind::InvalidInput, "Not unique"));
         }
+
+        Ok(())
+    }
+
+    /// Get this BindingTable's unique id.
+    fn get_id(&self) -> usize {
+        self.id
     }
 
     // ###############################
     // P U B L I C  F U N C T I O N S
     // ###############################
 
-    /// Add a binding to the table.
-    pub fn add_binding(&mut self, binding : Binding) {
-        self.ensure_unique(binding.key);
-        self.bindings.push(binding);
-    }
+    /// Bind some an action to a key.
+    pub fn bind(&mut self, key : Key, action : &Arrow)
+        -> io::Result<()> {
+        self.ensure_unique(key)?;
 
-    /// Get this BindingTable's unique id.
-    pub fn get_id(&self) -> usize {
-        self.id
+        self.bindings.push(Binding {
+            key,
+            result : action.clone()
+        });
+
+        Ok(())
     }
 
     /// Make a new BindingTable without anything in it.
@@ -151,17 +166,18 @@ impl Keymaster {
     /// Get the current state (i.e the current binding table) of
     /// the Keymaster. If the current table has not been set, it
     /// will be set to the root table.
-    fn get_state(&self) -> &BindingTable {
-        self.get_table(self.current_table).unwrap()
+    fn get_state(&mut self) -> &mut BindingTable {
+        let id = self.current_table;
+        self.get_table_by_id(id).unwrap()
     }
 
     /// Get a reference to a table given its id.
-    fn get_table(&self, id : usize) -> Option<&BindingTable> {
+    fn get_table_by_id(&mut self, id : usize) -> Option<&mut BindingTable> {
         if id == 0 {
-            return Some(&self.root_table)
+            return Some(&mut self.root_table)
         }
 
-        self.tables.iter().find(|ref x| x.id == id)
+        self.tables.iter_mut().find(|ref x| x.id == id)
     }
 
     /// Interpret the result of a Arrow enum. If a function
@@ -175,12 +191,12 @@ impl Keymaster {
             Arrow::Table(ref table) => {
                 let id = *table;
 
-                if let Some(_) = self.get_table(id) {
+                if let Some(_) = self.get_table_by_id(id) {
                     self.current_table = id;
                 }
             },
             Arrow::Root => {
-                self.go_home();
+                self.to_root();
             },
             Arrow::Nothing => {}
         }
@@ -189,15 +205,16 @@ impl Keymaster {
     }
 
     /// Make a new table with an assigned id.
-    fn new_table(&mut self) -> &BindingTable {
-        self.tables.push(BindingTable::new(self.id_counter));
+    fn new_table(&mut self) -> &mut BindingTable {
+        let id = self.id_counter;
+        self.tables.push(BindingTable::new(id));
         self.id_counter += 1;
-        self.get_table(self.id_counter - 1).unwrap()
+        self.get_table_by_id(id - 1).unwrap()
     }
 
     /// Attempt to get an action for a key if it is
     /// evaluated in the current binding table.
-    fn search_key(&self, key : Key) -> Option<&Arrow> {
+    fn search_key(&mut self, key : Key) -> Option<&Arrow> {
         self.get_state().search_key(key)
     }
 
@@ -227,8 +244,108 @@ impl Keymaster {
         return self.handle_action(&action);
     }
 
+    /// Get the root binding table.
+    pub fn get_root(&mut self) -> &mut BindingTable {
+        self.get_table_by_id(0).unwrap()
+    }
+
+    /// Get a binding table according to a sequence of keys, which
+    /// are evaluated starting at the root. Will only return Some
+    /// if the keys evaluate to a state that is a table.
+    pub fn get_table<T: AsRef<[Key]>>(&mut self, sequence : T) -> Option<&mut BindingTable> {
+        let mut id = 0;
+
+        for key in sequence.as_ref().iter() {
+            let mut table = self.get_table_by_id(id).unwrap();
+            let binding = table.search_key(*key);
+
+            if binding.is_none() {
+                return None;
+            }
+
+            match *binding.unwrap() {
+                Arrow::Table(ref index) => {
+                    id = *index;
+                },
+                _ => {
+                    return None;
+                }
+            }
+        }
+
+        if id == 0 {
+            return None;
+        }
+
+        self.get_table_by_id(id)
+    }
+
+    /// Make a new table at the end of a prefix of keys. If the arrows
+    /// to reach this table from the root do not already exist, they
+    /// will be created.
+    /// 
+    /// If you give this function a slice consisting of just Key::Char('a')
+    /// and add a binding to the returned table, you can use that binding
+    /// by typing 'a' then that binding.
+    pub fn make_table<T: AsRef<[Key]>>(&mut self, prefix : T) 
+        -> io::Result<usize> 
+    {
+        // The id of the table that does not have the prefix
+        // binding.
+        let mut max_id = 0;
+        let mut max_index = 0;
+        let mut should_make = false;
+
+        // We need to find where we need to start making tables.
+
+        for key in prefix.as_ref().iter() {
+            let mut table = self.get_table_by_id(max_id).unwrap();
+            let binding = table.search_key(*key);
+
+            if binding.is_none() {
+                should_make = true;
+                break;
+            }
+
+            match *binding.unwrap() {
+                Arrow::Table(ref index) => {
+                    max_id = *index;
+                },
+                _ => {
+                    return Err(Error::new(ErrorKind::InvalidInput, "Binding already exists"));
+                }
+            }
+
+            max_index += 1;
+        }
+
+        if should_make {
+            let (_, rest)   = prefix.as_ref().split_at(max_index);
+            let mut last    = max_id;
+            let mut current = self.id_counter;
+
+            for key in rest.iter() {
+                self.new_table();
+            }
+
+            for key in rest.iter() {
+                // jenni is a qt and I am so tired of working on this
+                let mut table = self.get_table_by_id(last).unwrap();
+                let arrow = Arrow::Table(current);
+                table.bind(*key, &arrow);
+
+                current += 1;
+                last     = current;
+            }
+
+            max_id = last;
+        }
+
+        Ok(max_id)
+    }
+
     /// Return to the initial (root) state.
-    pub fn go_home(&mut self) {
+    pub fn to_root(&mut self) {
         self.current_table = 0;
     }
 

--- a/src/byt/io/binds/mod.rs
+++ b/src/byt/io/binds/mod.rs
@@ -287,7 +287,7 @@ impl Keymaster {
     /// If you give this function a slice consisting of just Key::Char('a')
     /// and add a binding to the returned table, you can use that binding
     /// by typing 'a' then that binding.
-    pub fn make_table<T: AsRef<[Key]>>(&mut self, prefix : T) 
+    pub fn make_prefix<T: AsRef<[Key]>>(&mut self, prefix : T) 
         -> io::Result<usize> 
     {
         // The id of the table that does not have the prefix

--- a/src/byt/io/binds/mod.rs
+++ b/src/byt/io/binds/mod.rs
@@ -12,7 +12,7 @@ use std::io::{
 use std::io;
 
 // SUBMODULES
-//mod tests;
+mod tests;
 
 // LOCAL INCLUDES
 
@@ -20,7 +20,7 @@ use std::io;
 /// the state machine reaches this state. It's called an arrow
 /// because it refers to the next state, even if that involves
 /// sending an action up to the editor as a result.
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Debug)]
 enum Arrow {
     /// Triggers some kind of action within the editor.
     /// In the future this will be a reference to a closure, probably.
@@ -95,7 +95,7 @@ impl BindingTable {
     // ###############################
 
     /// Bind some an action to a key.
-    pub fn bind(&mut self, key : Key, action : &Arrow)
+    pub fn bind(&mut self, key : Key, action : Arrow)
         -> io::Result<()> {
         self.ensure_unique(key)?;
 
@@ -292,8 +292,8 @@ impl Keymaster {
     {
         // The id of the table that does not have the prefix
         // binding.
-        let mut max_id = 0;
-        let mut max_index = 0;
+        let mut max_id      = 0;
+        let mut max_index   = 0;
         let mut should_make = false;
 
         // We need to find where we need to start making tables.
@@ -331,11 +331,10 @@ impl Keymaster {
             for key in rest.iter() {
                 // jenni is a qt and I am so tired of working on this
                 let mut table = self.get_table_by_id(last).unwrap();
-                let arrow = Arrow::Table(current);
-                table.bind(*key, &arrow);
+                table.bind(*key, Arrow::Table(current));
 
-                current += 1;
-                last     = current;
+                last    = current;
+                current = last + 1;
             }
 
             max_id = last;

--- a/src/byt/io/binds/mod.rs
+++ b/src/byt/io/binds/mod.rs
@@ -25,6 +25,9 @@ pub enum Arrow {
     /// Refers to a table within the Keymaster
     Table(usize),
 
+    /// Go back to the root table.
+    Root,
+
     /// Stay in the current table and do nothing.
     Nothing
 }
@@ -176,6 +179,9 @@ impl Keymaster {
                     self.current_table = id;
                 }
             },
+            Arrow::Root => {
+                self.go_home();
+            },
             Arrow::Nothing => {}
         }
 
@@ -189,26 +195,18 @@ impl Keymaster {
         self.get_table(self.id_counter - 1).unwrap()
     }
 
-    // ###############################
-    // P U B L I C  F U N C T I O N S
-    // ###############################
-
-    /// Create a new Keymaster and return it.
-    /// Initially there are nothing in its bindings.
-    pub fn new() -> Keymaster {
-        Keymaster {
-            root_table : BindingTable::new(0),
-            current_table : 0,
-            tables : Vec::new(),
-            id_counter : 1
-        }
-    }
-
+    /// Attempt to get an action for a key if it is
+    /// evaluated in the current binding table.
     fn search_key(&self, key : Key) -> Option<&Arrow> {
         self.get_state().search_key(key)
     }
 
-    /// Handle a key of new user input.
+    // ###############################
+    // P U B L I C  F U N C T I O N S
+    // ###############################
+
+    /// Handle a key of new user input. If an action got fired
+    /// this method will return it.
     pub fn consume(&mut self, key : Key) -> Option<String> {
         let mut action : Arrow;
 
@@ -227,5 +225,21 @@ impl Keymaster {
         }
 
         return self.handle_action(&action);
+    }
+
+    /// Return to the initial (root) state.
+    pub fn go_home(&mut self) {
+        self.current_table = 0;
+    }
+
+    /// Create a new Keymaster and return it.
+    /// Initially there are nothing in its bindings.
+    pub fn new() -> Keymaster {
+        Keymaster {
+            root_table : BindingTable::new(0),
+            current_table : 0,
+            tables : Vec::new(),
+            id_counter : 1
+        }
     }
 }

--- a/src/byt/io/binds/mod.rs
+++ b/src/byt/io/binds/mod.rs
@@ -19,7 +19,7 @@ use byt::editor::{Action, Actionable};
 
 /// Acts as a transition arrow between states of the state machine.
 #[derive(Clone, PartialEq, Debug)]
-enum Arrow {
+pub enum Arrow {
     /// Triggers some kind of action within the editor.
     /// In the future this will be a reference to a closure, probably.
     /// For now we just use strings for ease of testing.
@@ -365,6 +365,11 @@ impl Keymaster {
         self.get_table_by_id(table).unwrap().bind(last[0], action)
     }
 
+    /// Bind a mutator action to a sequence.
+    pub fn bind_action<T: AsRef<[Key]>>(&mut self, sequence : T, action : &str) -> io::Result<()> {
+        self.bind(sequence, Arrow::Function(Action::Mutator(String::from(action))))
+    }
+
     /// Remove the action and any tables that reference it. Any of the action's
     /// parents back to the root table will be destroyed if they only contained
     /// this binding.
@@ -423,17 +428,6 @@ impl Keymaster {
         self.get_table_by_id(0).unwrap()
     }
 
-    /// Pop an action that can be consumed.
-    pub fn grab_action(&mut self) -> Option<Action> {
-        self.actions.pop()
-    }
-
-    /// Check whether we can consume an action.
-    pub fn has_action(&self) -> bool {
-        self.actions.len() > 0
-    }
-
-
     /// Return to the initial (root) state.
     pub fn to_root(&mut self) {
         self.current_table = 0;
@@ -449,6 +443,12 @@ impl Keymaster {
             id_counter : 1,
             actions : Vec::new()
         }
+    }
+}
+
+impl Actionable for Keymaster {
+    fn actions(&mut self) -> Vec<Action> {
+        self.actions.drain(..).collect()
     }
 }
 

--- a/src/byt/io/binds/tests.rs
+++ b/src/byt/io/binds/tests.rs
@@ -6,32 +6,29 @@ use super::*;
 mod tables {
     use super::*;
 
-    //#[test]
-    //fn it_returns_no_empty_wildcard() {
-        //let mut table = BindingTable::new();
-        //assert!(table.search_key(Key::Char('b')).is_none());
-    //}
+    #[test]
+    fn it_returns_no_empty_wildcard() {
+        let mut table = BindingTable::new(0);
+        assert!(table.search_key(Key::Char('b')).is_none());
+    }
 
-    //#[test]
-    //fn it_returns_the_wildcard() {
-        //let mut table = BindingTable::new();
+    #[test]
+    fn it_returns_the_wildcard() {
+        let mut table = BindingTable::new(0);
 
-        //table.set_wildcard(Action::Function(String::from("foobar")));
+        table.set_wildcard(Arrow::Function(String::from("foobar")));
 
-        //assert!(table.search_key(Key::Char('b')).is_some());
-    //}
+        assert!(table.search_key(Key::Char('b')).is_some());
+    }
 
-    //#[test]
-    //fn it_finds_a_binding() {
-        //let mut table = BindingTable::new();
+    #[test]
+    fn it_finds_a_binding() {
+        let mut table = BindingTable::new(0);
 
-        //table.add_binding(Binding {
-            //key : Key::Char('a'),
-            //result : Action::Nothing
-        //});
+        table.bind(Key::Char('a'), Arrow::Nothing);
 
-        //assert!(table.search_key(Key::Char('a')).is_some());
-    //}
+        assert!(table.search_key(Key::Char('a')).is_some());
+    }
 }
 
 #[test]
@@ -57,10 +54,13 @@ fn it_finds_a_wildcard() {
 }
 
 #[test]
+/// Ensure that the Keymaster creates all of the tables as necessary
+/// and then responds to input that uses them properly when using
+/// the make_prefix function.
 fn it_handles_depth() {
     let mut master = Keymaster::new();
 
-    let id = master.make_table([Key::Char('b'), Key::Char('a')]).unwrap();
+    let id = master.make_prefix([Key::Char('b'), Key::Char('a')]).unwrap();
 
     assert_eq!(master.tables.len(), 2);
 

--- a/src/byt/io/binds/tests.rs
+++ b/src/byt/io/binds/tests.rs
@@ -71,8 +71,8 @@ fn it_unbinds_a_sequence() {
     let seq = [Key::Char('b'), Key::Char('a'), Key::Char('r')];
 
     master.bind(seq, Arrow::Table(0));
-    assert!(master.unbind(seq).is_ok());
 
+    assert!(master.unbind(seq).is_ok());
     assert!(master.consume(Key::Char('b')).is_none());
     assert!(master.consume(Key::Char('a')).is_none());
     assert!(master.consume(Key::Char('r')).is_none());

--- a/src/byt/io/binds/tests.rs
+++ b/src/byt/io/binds/tests.rs
@@ -16,7 +16,7 @@ mod tables {
     fn it_returns_the_wildcard() {
         let mut table = BindingTable::new(0);
 
-        table.set_wildcard(Arrow::Function(Action::View(String::from("Blah"))));
+        table.set_wildcard(Arrow::Function(Action::Mutator(String::from("Blah"))));
 
         assert!(table.search_key(Key::Char('b')).is_some());
     }
@@ -48,7 +48,7 @@ fn it_finds_a_wildcard() {
 
     master
         .get_root()
-        .set_wildcard(Arrow::Function(Action::View(String::from("Blah"))));
+        .set_wildcard(Arrow::Function(Action::Mutator(String::from("Blah"))));
 
     assert!(master.search_key(Key::Char('a')).is_some());
 }
@@ -108,7 +108,7 @@ fn it_handles_depth() {
     master
         .get_table_by_id(id)
         .unwrap()
-        .bind(Key::Char('r'), Arrow::Function(Action::View(String::from("Blah"))));
+        .bind(Key::Char('r'), Arrow::Function(Action::Mutator(String::from("Blah"))));
 
     master.consume(Key::Char('b'));
     master.consume(Key::Char('a'));

--- a/src/byt/io/binds/tests.rs
+++ b/src/byt/io/binds/tests.rs
@@ -6,64 +6,41 @@ use super::*;
 mod tables {
     use super::*;
 
-    #[test]
-    fn it_returns_no_empty_wildcard() {
-        let mut table = BindingTable::new();
-        assert!(table.search_key(Key::Char('b')).is_none());
-    }
+    //#[test]
+    //fn it_returns_no_empty_wildcard() {
+        //let mut table = BindingTable::new();
+        //assert!(table.search_key(Key::Char('b')).is_none());
+    //}
 
-    #[test]
-    fn it_returns_the_wildcard() {
-        let mut table = BindingTable::new();
+    //#[test]
+    //fn it_returns_the_wildcard() {
+        //let mut table = BindingTable::new();
 
-        table.set_wildcard(Action::Function(String::from("foobar")));
+        //table.set_wildcard(Action::Function(String::from("foobar")));
 
-        assert!(table.search_key(Key::Char('b')).is_some());
-    }
+        //assert!(table.search_key(Key::Char('b')).is_some());
+    //}
 
-    #[test]
-    fn it_finds_a_binding() {
-        let mut table = BindingTable::new();
+    //#[test]
+    //fn it_finds_a_binding() {
+        //let mut table = BindingTable::new();
 
-        table.add_binding(Binding {
-            key : Key::Char('a'),
-            result : Action::Nothing
-        });
+        //table.add_binding(Binding {
+            //key : Key::Char('a'),
+            //result : Action::Nothing
+        //});
 
-        assert!(table.search_key(Key::Char('a')).is_some());
-    }
+        //assert!(table.search_key(Key::Char('a')).is_some());
+    //}
 }
 
 #[test]
 fn it_finds_a_binding() {
     let mut master = Keymaster::new();
-    let mut table = BindingTable::new();
 
-    table.add_binding(Binding {
-        key : Key::Char('a'),
-        result : Action::Nothing
-    });
-
-    master.add_table(table);
-
-    assert!(master.search_key(Key::Char('a')).is_some());
-}
-
-#[test]
-fn it_finds_a_lower_binding() {
-    let mut master = Keymaster::new();
-    let mut global = BindingTable::new();
-
-    global.add_binding(Binding {
-        key : Key::Char('a'),
-        result : Action::Nothing
-    });
-
-    master.add_table(global);
-    
-    // We want to ensure the master checks tables lower
-    // in the stack if it doesn't find anything.
-    master.add_table(BindingTable::new());
+    master
+        .get_root()
+        .bind(Key::Char('a'), Arrow::Nothing);
 
     assert!(master.search_key(Key::Char('a')).is_some());
 }
@@ -72,32 +49,45 @@ fn it_finds_a_lower_binding() {
 fn it_finds_a_wildcard() {
     let mut master = Keymaster::new();
 
-    let mut table = BindingTable::new();
-    table.set_wildcard(Action::Function(String::from("foobar")));
-
-    master.add_table(table);
+    master
+        .get_root()
+        .set_wildcard(Arrow::Function(String::from("foobar")));
 
     assert!(master.search_key(Key::Char('a')).is_some());
 }
 
 #[test]
-fn it_pops_a_table() {
+fn it_handles_depth() {
     let mut master = Keymaster::new();
 
-    let mut first = BindingTable::new();
-    first.add_binding(Binding {
-        key : Key::Char('a'),
-        result : Action::Nothing
-    });
-    master.add_table(first);
+    let id = master.make_table([Key::Char('b'), Key::Char('a')]).unwrap();
 
-    let mut second = BindingTable::new();
-    second.add_binding(Binding {
-        key : Key::Char('a'),
-        result : Action::Pop
-    });
-    master.add_table(second);
+    assert_eq!(master.tables.len(), 2);
 
+    {
+        let table = &master.root_table.bindings;
+        assert_eq!(table.len(), 1);
+        assert_eq!(table[0].key, Key::Char('b'));
+        assert_eq!(table[0].result, Arrow::Table(1));
+    }
+
+    {
+        let table = &master.tables[0].bindings;
+        assert_eq!(table.len(), 1);
+        assert_eq!(table[0].key, Key::Char('a'));
+        assert_eq!(table[0].result, Arrow::Table(2));
+    }
+
+    assert!(master.get_table_by_id(id).is_some());
+
+    master
+        .get_table_by_id(id)
+        .unwrap()
+        .bind(Key::Char('r'), Arrow::Function(String::from("wtf")));
+
+    master.consume(Key::Char('b'));
     master.consume(Key::Char('a'));
-    assert!(master.tables.len() == 1);
+
+    assert_eq!(master.current_table, 2);
+    assert!(master.consume(Key::Char('r')).is_some());
 }

--- a/src/byt/io/binds/tests.rs
+++ b/src/byt/io/binds/tests.rs
@@ -16,7 +16,7 @@ mod tables {
     fn it_returns_the_wildcard() {
         let mut table = BindingTable::new(0);
 
-        table.set_wildcard(Arrow::Function(Action {}));
+        table.set_wildcard(Arrow::Function(Action::View(String::from("Blah"))));
 
         assert!(table.search_key(Key::Char('b')).is_some());
     }
@@ -48,7 +48,7 @@ fn it_finds_a_wildcard() {
 
     master
         .get_root()
-        .set_wildcard(Arrow::Function(Action {}));
+        .set_wildcard(Arrow::Function(Action::View(String::from("Blah"))));
 
     assert!(master.search_key(Key::Char('a')).is_some());
 }
@@ -108,7 +108,7 @@ fn it_handles_depth() {
     master
         .get_table_by_id(id)
         .unwrap()
-        .bind(Key::Char('r'), Arrow::Function(Action {}));
+        .bind(Key::Char('r'), Arrow::Function(Action::View(String::from("Blah"))));
 
     master.consume(Key::Char('b'));
     master.consume(Key::Char('a'));

--- a/src/byt/io/binds/tests.rs
+++ b/src/byt/io/binds/tests.rs
@@ -16,7 +16,7 @@ mod tables {
     fn it_returns_the_wildcard() {
         let mut table = BindingTable::new(0);
 
-        table.set_wildcard(Arrow::Function(String::from("foobar")));
+        table.set_wildcard(Arrow::Function(Action {}));
 
         assert!(table.search_key(Key::Char('b')).is_some());
     }
@@ -48,9 +48,34 @@ fn it_finds_a_wildcard() {
 
     master
         .get_root()
-        .set_wildcard(Arrow::Function(String::from("foobar")));
+        .set_wildcard(Arrow::Function(Action {}));
 
     assert!(master.search_key(Key::Char('a')).is_some());
+}
+
+#[test]
+fn it_binds_a_sequence() {
+    let mut master = Keymaster::new();
+    let seq = [Key::Char('b'), Key::Char('a'), Key::Char('r')];
+
+    master.bind(seq, Arrow::Table(0));
+
+    assert!(master.consume(Key::Char('b')).is_some());
+    assert!(master.consume(Key::Char('a')).is_some());
+    assert!(master.consume(Key::Char('r')).is_some());
+}
+
+#[test]
+fn it_unbinds_a_sequence() {
+    let mut master = Keymaster::new();
+    let seq = [Key::Char('b'), Key::Char('a'), Key::Char('r')];
+
+    master.bind(seq, Arrow::Table(0));
+    assert!(master.unbind(seq).is_ok());
+
+    assert!(master.consume(Key::Char('b')).is_none());
+    assert!(master.consume(Key::Char('a')).is_none());
+    assert!(master.consume(Key::Char('r')).is_none());
 }
 
 #[test]
@@ -83,7 +108,7 @@ fn it_handles_depth() {
     master
         .get_table_by_id(id)
         .unwrap()
-        .bind(Key::Char('r'), Arrow::Function(String::from("wtf")));
+        .bind(Key::Char('r'), Arrow::Function(Action {}));
 
     master.consume(Key::Char('b'));
     master.consume(Key::Char('a'));

--- a/src/byt/mod.rs
+++ b/src/byt/mod.rs
@@ -28,6 +28,7 @@ mod views;
 
 // LOCAL INCLUDES
 use byt::editor::{Action, Actionable};
+use byt::editor::mutator::*;
 use byt::io::binds::KeyInput;
 use byt::io::file;
 use byt::render::Renderable;
@@ -52,9 +53,9 @@ pub fn init() {
 
     let (sender, receiver) = channel::<Event>();
 
-    let mut editor = editor::Editor::new();
+    let mut editor = MutatePair::new(editor::Editor::new());
 
-    editor.open("README.md");
+    editor.target_mut().open("README.md");
 
     // One thread just reads from user input and makes
     // events from whatever it gets.
@@ -84,8 +85,11 @@ pub fn init() {
                 continue;
             }
 
-            let action = editor.grab_action().unwrap();
-            sender.send(Event::Function(action));
+            for action in editor.actions() {
+                if let Action::Mutator(name) = action {
+                    editor.call_action(name.as_str());
+                }
+            }
         }
 
         // Check if we should render

--- a/src/byt/mod.rs
+++ b/src/byt/mod.rs
@@ -76,7 +76,8 @@ pub fn init() {
                 continue;
             }
 
-            sender.send(Event::Function(editor.grab_action().unwrap()));
+            let action = editor.grab_action().unwrap();
+            sender.send(Event::Function(action));
         }
 
         //// Check if we should render

--- a/src/byt/mod.rs
+++ b/src/byt/mod.rs
@@ -27,7 +27,8 @@ mod render;
 mod views;
 
 // LOCAL INCLUDES
-use byt::editor::Action;
+use byt::editor::{Action, Actionable};
+use byt::io::binds::KeyInput;
 use byt::io::file;
 use byt::render::Renderable;
 use self::events::*;

--- a/src/byt/mod.rs
+++ b/src/byt/mod.rs
@@ -56,10 +56,13 @@ pub fn init() {
     let (sender, receiver) = channel::<Event>();
 
     let mut editor = MutatePair::new(editor::Editor::new());
-
-    editor.register_mutator(Box::new(Vym::new()));
-
     editor.target_mut().open("README.md");
+
+    editor
+        .target_mut()
+        .current_file()
+        .unwrap()
+        .register_mutator(Box::new(Vym::new()));
 
     // One thread just reads from user input and makes
     // events from whatever it gets.

--- a/src/byt/mod.rs
+++ b/src/byt/mod.rs
@@ -23,6 +23,7 @@ use termion;
 mod editor;
 mod events;
 mod io;
+mod mutators;
 mod render;
 mod views;
 
@@ -32,6 +33,7 @@ use byt::editor::mutator::*;
 use byt::io::binds::KeyInput;
 use byt::io::file;
 use byt::render::Renderable;
+use byt::mutators::vym::Vym;
 use self::events::*;
 
 /// Initialize and start byt.
@@ -54,6 +56,8 @@ pub fn init() {
     let (sender, receiver) = channel::<Event>();
 
     let mut editor = MutatePair::new(editor::Editor::new());
+
+    editor.register_mutator(Box::new(Vym::new()));
 
     editor.target_mut().open("README.md");
 

--- a/src/byt/mod.rs
+++ b/src/byt/mod.rs
@@ -51,32 +51,6 @@ pub fn init() {
 
     let mut key_handler = io::binds::Keymaster::new();
 
-    {
-        let mut table = io::binds::BindingTable::new();
-
-        table.add_binding(io::binds::Binding::new(
-                Key::Char('q'),
-                io::binds::Action::Function(String::from("quit")),
-                ));
-
-        table.add_binding(io::binds::Binding::new(
-                Key::Char('a'),
-                io::binds::Action::Function(String::from("render")),
-                ));
-
-        table.add_binding(io::binds::Binding::new(
-                Key::Char('l'),
-                io::binds::Action::Function(String::from("right")),
-                ));
-
-        table.add_binding(io::binds::Binding::new(
-                Key::Char('h'),
-                io::binds::Action::Function(String::from("left")),
-                ));
-
-        key_handler.add_table(table);
-    }
-
     // One thread just reads from user input and makes
     // events from whatever it gets.
     let key_sender = sender.clone();

--- a/src/byt/mod.rs
+++ b/src/byt/mod.rs
@@ -54,6 +54,8 @@ pub fn init() {
 
     let mut editor = editor::Editor::new();
 
+    editor.open("README.md");
+
     // One thread just reads from user input and makes
     // events from whatever it gets.
     let key_sender = sender.clone();
@@ -71,6 +73,11 @@ pub fn init() {
         let sender = sender.clone();
 
         if let Event::KeyPress(key) = event {
+            // Just for now while I mess with other things
+            if key == Key::Char('q') {
+                break;
+            }
+
             let result = editor.consume(key);
 
             if result.is_none() {
@@ -81,30 +88,21 @@ pub fn init() {
             sender.send(Event::Function(action));
         }
 
-        //// Check if we should render
-        //let mut should_render = false;
-        //for file in files.iter() {
-            //should_render = should_render || file.should_render();
-        //}
+        // Check if we should render
+        if !editor.should_render() {
+            continue;
+        }
 
-        //if !should_render {
-            //continue;
-        //}
+        let size = termion::terminal_size().unwrap();
 
-        //let size = termion::terminal_size().unwrap();
+        // Clear the screen before rendering
+        write!(screen, "{}", termion::clear::All);
 
-        //// Clear the screen before rendering
-        //write!(screen, "{}", termion::clear::All);
+        {
+            let mut renderer = render::terminal::TermRenderer::new(&mut screen);
+            editor.render(&mut renderer, size);
+        }
 
-        //for file in files.iter_mut() {
-            //if !file.should_render() {
-                //continue;
-            //}
-
-            //let mut renderer = render::terminal::TermRenderer::new(&mut screen);
-            //file.render(&mut renderer, size);
-        //}
-
-        //screen.flush().unwrap();
+        screen.flush().unwrap();
     }
 }

--- a/src/byt/mutators/mod.rs
+++ b/src/byt/mutators/mod.rs
@@ -1,0 +1,1 @@
+pub mod vym;

--- a/src/byt/mutators/template.rs
+++ b/src/byt/mutators/template.rs
@@ -1,0 +1,53 @@
+//! byt - template
+//!
+//! Template for a new mutator.
+
+// EXTERNS
+
+// LIBRARY INCLUDES
+
+// SUBMODULES
+
+// LOCAL INCLUDES
+use byt::editor::mutator::*;
+use byt::editor::*;
+
+// TODO add comments and explain everything
+
+struct BasicMutator {
+}
+
+impl Mutator<Editor> for BasicMutator {
+}
+
+impl Actionable for BasicMutator {
+    fn actions(&mut self) -> Vec<Action> {
+        Vec::new()
+    }
+}
+
+impl Renderable for BasicMutator {
+    fn render(&mut self, renderer : &mut render::Renderer, size : (u16, u16)) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn should_render(&self) -> bool {
+        false
+    }
+}
+
+impl Scope<Editor> for BasicMutator {
+    fn has_function(&self, name : &str) -> bool {
+        false
+    }
+
+    fn call(&mut self, name : &str, target : &mut T) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl KeyInput for BasicMutator {
+    fn consume(&mut self, key : Key) -> Option<()> {
+        None
+    }
+}

--- a/src/byt/mutators/vym.rs
+++ b/src/byt/mutators/vym.rs
@@ -15,6 +15,7 @@ use byt::editor::mutator::*;
 use byt::editor::*;
 use byt::render;
 use byt::render::Renderable;
+use byt::views::file::FileView;
 use byt::io::binds::{Arrow, Keymaster, KeyInput};
 
 // TODO add comments and explain everything
@@ -24,12 +25,12 @@ fn init_vym(vym : &mut Vym) {
     let mut rust = &mut vym.rust;
 
     rust.register("vym.right", |state, target| {
-        target.current_file().unwrap().move_right();
+        target.move_right();
     });
     keys.bind_action([Key::Char('l')], "vym.right");
 
     rust.register("vym.left", |state, target| {
-        target.current_file().unwrap().move_left();
+        target.move_left();
     });
     keys.bind_action([Key::Char('h')], "vym.left");
 }
@@ -39,7 +40,7 @@ struct VymState {
 }
 
 pub struct Vym<'a> {
-    rust : RustScope<'a, VymState, Editor>,
+    rust : RustScope<'a, VymState, FileView>,
     keys : Keymaster
 }
 
@@ -56,7 +57,7 @@ impl<'a> Vym<'a> {
     }
 }
 
-impl<'a> Mutator<Editor> for Vym<'a> {
+impl<'a> Mutator<FileView> for Vym<'a> {
 }
 
 impl<'a> Actionable for Vym<'a> {
@@ -75,12 +76,12 @@ impl<'a> Renderable for Vym<'a> {
     }
 }
 
-impl<'a> Scope<Editor> for Vym<'a> {
+impl<'a> Scope<FileView> for Vym<'a> {
     fn has_function(&self, name : &str) -> bool {
         self.rust.has_function(name)
     }
 
-    fn call(&mut self, name : &str, target : &mut Editor) -> io::Result<()> {
+    fn call(&mut self, name : &str, target : &mut FileView) -> io::Result<()> {
         self.rust.call(name, target)
     }
 }

--- a/src/byt/mutators/vym.rs
+++ b/src/byt/mutators/vym.rs
@@ -1,0 +1,92 @@
+//! byt - vym
+//!
+//! Implement a mutator that mimic's vim's key layout.
+
+// EXTERNS
+
+// LIBRARY INCLUDES
+use termion::event::Key;
+use std::io;
+
+// SUBMODULES
+
+// LOCAL INCLUDES
+use byt::editor::mutator::*;
+use byt::editor::*;
+use byt::render;
+use byt::render::Renderable;
+use byt::io::binds::{Arrow, Keymaster, KeyInput};
+
+// TODO add comments and explain everything
+
+fn init_vym(vym : &mut Vym) {
+    let mut keys = &mut vym.keys;
+    let mut rust = &mut vym.rust;
+
+    rust.register("vym.right", |state, target| {
+        target.current_file().unwrap().move_right();
+    });
+    keys.bind_action([Key::Char('l')], "vym.right");
+
+    rust.register("vym.left", |state, target| {
+        target.current_file().unwrap().move_left();
+    });
+    keys.bind_action([Key::Char('h')], "vym.left");
+}
+
+struct VymState {
+    mode : u8
+}
+
+pub struct Vym<'a> {
+    rust : RustScope<'a, VymState, Editor>,
+    keys : Keymaster
+}
+
+impl<'a> Vym<'a> {
+    pub fn new() -> Vym<'a> {
+        let mut vym = Vym {
+            rust  : RustScope::new(VymState { mode : 0 }),
+            keys  : Keymaster::new()
+        };
+
+        init_vym(&mut vym);
+
+        vym
+    }
+}
+
+impl<'a> Mutator<Editor> for Vym<'a> {
+}
+
+impl<'a> Actionable for Vym<'a> {
+    fn actions(&mut self) -> Vec<Action> {
+        self.keys.actions()
+    }
+}
+
+impl<'a> Renderable for Vym<'a> {
+    fn render(&mut self, renderer : &mut render::Renderer, size : (u16, u16)) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn should_render(&self) -> bool {
+        false
+    }
+}
+
+impl<'a> Scope<Editor> for Vym<'a> {
+    fn has_function(&self, name : &str) -> bool {
+        self.rust.has_function(name)
+    }
+
+    fn call(&mut self, name : &str, target : &mut Editor) -> io::Result<()> {
+        self.rust.call(name, target)
+    }
+}
+
+impl<'a> KeyInput for Vym<'a> {
+    fn consume(&mut self, key : Key) -> Option<()> {
+        self.keys.consume(key)
+    }
+}

--- a/src/byt/mutators/vym.rs
+++ b/src/byt/mutators/vym.rs
@@ -68,6 +68,7 @@ impl<'a> Actionable for Vym<'a> {
 
 impl<'a> Renderable for Vym<'a> {
     fn render(&mut self, renderer : &mut render::Renderer, size : (u16, u16)) -> io::Result<()> {
+        let (rows, cols) = size;
         Ok(())
     }
 

--- a/src/byt/views/file.rs
+++ b/src/byt/views/file.rs
@@ -15,9 +15,12 @@ use std::io::SeekFrom;
 // SUBMODULES
 
 // LOCAL INCLUDES
+use byt::io::binds::Keymaster;
 use byt::io::file::PieceFile;
 use byt::render;
 
+/// Analogous to a buffer in vim. Offers abstractions
+/// over byt's PieceFile type.
 pub struct FileView {
     /// The path to the file this FileView references.
     path : Option<String>,
@@ -37,6 +40,10 @@ pub struct FileView {
     /// Whether or not this view should be rendered after
     /// the next event.
     _should_render : bool,
+
+    /// Stores and interprets keybindings for this buffer
+    /// in particular.
+    keys : Keymaster,
 }
 
 impl FileView {
@@ -89,6 +96,7 @@ impl FileView {
             viewport_top : 0,
             lines : Vec::new(),
             _should_render : true,
+            keys  : Keymaster::new(),
         })
     }
 
@@ -130,6 +138,7 @@ impl FileView {
             viewport_top : 0,
             lines : Vec::new(),
             _should_render : true,
+            keys  : Keymaster::new(),
         };
 
         view.regenerate_lines();

--- a/src/byt/views/file.rs
+++ b/src/byt/views/file.rs
@@ -8,9 +8,11 @@
 use std::cmp;
 use std::fs::File;
 use std::fs;
-use std::io::{BufReader, ErrorKind, Error, Result};
 use std::io::Seek;
 use std::io::SeekFrom;
+use std::io::{BufReader, ErrorKind, Error, Result};
+use std::io;
+use termion::event::Key;
 
 // SUBMODULES
 
@@ -18,6 +20,12 @@ use std::io::SeekFrom;
 use byt::io::binds::Keymaster;
 use byt::io::file::PieceFile;
 use byt::render;
+use byt::editor::{
+    Action,
+    Actionable,
+    mutator
+};
+use byt::io::binds::KeyInput;
 
 /// Analogous to a buffer in vim. Offers abstractions
 /// over byt's PieceFile type.
@@ -44,6 +52,8 @@ pub struct FileView {
     /// Stores and interprets keybindings for this buffer
     /// in particular.
     keys : Keymaster,
+
+    mutators : Vec<Box<mutator::Mutator<FileView>>>,
 }
 
 impl FileView {
@@ -97,6 +107,7 @@ impl FileView {
             lines : Vec::new(),
             _should_render : true,
             keys  : Keymaster::new(),
+            mutators : Vec::new(),
         })
     }
 
@@ -139,6 +150,7 @@ impl FileView {
             lines : Vec::new(),
             _should_render : true,
             keys  : Keymaster::new(),
+            mutators : Vec::new(),
         };
 
         view.regenerate_lines();
@@ -160,6 +172,18 @@ impl FileView {
         self.viewport_top = cmp::min(line, (self.lines.len() - 1) as u64);
 
         Ok(())
+    }
+}
+
+impl KeyInput for FileView {
+    fn consume(&mut self, key : Key) -> Option<()> {
+        None
+    }
+}
+
+impl Actionable for FileView {
+    fn actions(&mut self) -> Vec<Action> {
+        Vec::new()
     }
 }
 


### PR DESCRIPTION
The whole goal of byt was to let bindings be their own independent state machine. The previous approach was an attempt at that but ultimately fell short. This rewrites the binding state machine logic to be more like a state machine and less like a stack.